### PR TITLE
Revert "CMakeLists.txt"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ endif()
 
 add_library( MulleObjCStandalone SHARED
 src/MulleObjCStandalone.m
-${HEADERS}
 ${DEF_FILE}
 )
 


### PR DESCRIPTION
Reverts mulle-nat/MulleObjC#1 because it's the wrong repository